### PR TITLE
fix LATCHINV, LATCHLO, LATCHHI?

### DIFF
--- a/std/cells.act
+++ b/std/cells.act
@@ -390,7 +390,7 @@ export defcell LATCHINV (bool? CLK, D, q; bool! _q)
   [iskeeper=1] q<10> & _clk -> _q-
 
   }
-  sizing { _clk{-2}; q{-1} }
+  sizing { _clk{-2} }
 }
 
 

--- a/std/cells.act
+++ b/std/cells.act
@@ -376,9 +376,9 @@ export defcell LATCH (bool? CLK, D; bool! Q)
   sizing { _clk{-2}; Q{-2} }
 }
 
-export defcell LATCHINV (bool? CLK, D; bool! _q)
+export defcell LATCHINV (bool? CLK, D, q; bool! _q)
 {
-  bool _clk, q;
+  bool _clk;
   prs {
     CLK => _clk-
 
@@ -389,8 +389,6 @@ export defcell LATCHINV (bool? CLK, D; bool! _q)
   [iskeeper=1;keeper=0] ~q<10> & ~CLK -> _q+
   [iskeeper=1] q<10> & _clk -> _q-
 
-  _q => q-
-
   }
   sizing { _clk{-2}; q{-1} }
 }
@@ -399,14 +397,14 @@ export defcell LATCHINV (bool? CLK, D; bool! _q)
 export defproc LATCHLO (bool? R, CLK, D; bool! Q)
 {
   bool _q;
-  LATCHINV l(CLK,D,_q);
+  LATCHINV l(CLK,D,Q,_q);
   NOR2X2 nx(_q,R,Q);
 }
  
 export defproc LATCHHI (bool? S, CLK, D; bool! Q)
 {
   bool _s, _q;
-  LATCHINV l(CLK,D,_q);
+  LATCHINV l(CLK,D,Q,_q);
   INVX1 ix(S,_s);
   NAND2X2 nx(_q,_s,Q);
 }


### PR DESCRIPTION
The inverter `_q => q-` in `LATCHINV` will lead to weak interference because the output signal `q` is also driven by a `NOR2X2` gate in `LATCHLO` or a `NAND2X2` gate in `LATCHHI`.

Another small issue is that in this version, `LATCHLO`/`LATCHHI` is a `proc` instead of a `cell`. In this case, the data capture delay from `D` to `Q` depends on the placement/routing result. Would it be better to keep them as atomic cells?