### PR TITLE
Use `defcell` for clock delay buffers

### DIFF
--- a/std/cells.act
+++ b/std/cells.act
@@ -99,9 +99,9 @@ defproc dbuf (bool? in; bool! out)
   }
 }
 
-export defproc CLKBUF1 <: dbuf<2>() { }
-export defproc CLKBUF2 <: dbuf<3>() { }
-export defproc CLKBUF3 <: dbuf<4>() { }
+export defcell CLKBUF1 <: dbuf<2>() { }
+export defcell CLKBUF2 <: dbuf<3>() { }
+export defcell CLKBUF3 <: dbuf<4>() { }
 
 
 /*--  signal buffers --*/


### PR DESCRIPTION
This PR changes the `CLKBUF{1,2,3}` standard definitions to use `defcell` instead of `defproc` which matches the rest of the cells defined here. Also, my basic understanding tells me that using `defproc` can lead to inconsistent delay timing since it will depend on where and how the place-and-route tool puts each of the buffer components.

I tested this briefly, and it seems to generate a pretty compact transistor layout with `sky130l` (below is a sample `CLKBUF1` layout I did quickly—it seems to work as expected in IRSim).

![CLKBUF1](https://github.com/user-attachments/assets/d4fbbf1d-5fd4-4315-b23d-9748f09fad8b)

Obviously, feel free to disregard if this is intentional, I just noticed that it didn't match other cells and figured I'd point it out in case it was a mistake.