### PR TITLE
Fixes for signed integer

### DIFF
--- a/math/fxp.act
+++ b/math/fxp.act
@@ -169,7 +169,9 @@ namespace math {
         [ x{A+B-1} = 1 -> sx+; x := ~x + 1 [] else -> sx- ];
         [ y{A+B-1} = 1 -> sy+; y := ~y + 1 [] else -> sy- ];
         r := (x * y);
-        self := (r >> B) + round<B,ROUNDING_MODE>(r{B}, r{B-1..0});
+        [ B > 0 -> self := (r >> B) + round<B,ROUNDING_MODE>(r{B}, r{B-1..0})
+       [] else -> self := r
+        ];
         [ sx != sy -> self := ~self + 1 [] else -> skip ]
       }
     }

--- a/math/sint.act
+++ b/math/sint.act
@@ -45,7 +45,7 @@ import math::fxp;
 namespace math {
     export
     template<pint W>
-    deftype sint <: fixpoint<W,0> () {}
+    deftype sint <: fixpoint<W,0,0> () {}
 
     export
     namespace sint_ops {


### PR DESCRIPTION
- avoid rounding in `mults` with zero fractional bits
- explicitly set rounding mode to `trunc` for signed int